### PR TITLE
Extremely lightweight dark-mode

### DIFF
--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -18,7 +18,6 @@ body {
   background-color: #f5f5f5;
 }
 
-
 /* Custom page CSS
 -------------------------------------------------- */
 /* Not required for template or sticky footer method. */
@@ -38,7 +37,18 @@ code {
 
 /* https://medium.com/@cjcnex/a-reflection-on-solving-blockquote-style-in-jekyll-e6109c8c03a */
 blockquote {
-  border-left: .25em solid #dfe2e5;
+  border-left: 0.25em solid #dfe2e5;
   color: #6a737d;
   padding: 0 1em;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    color: #bbb !important;
+    background-color: #222 !important;
+  }
+
+  .footer {
+    background-color: #111;
+  }
 }


### PR DESCRIPTION
For users who have set their operating systems to dark mode (eg, me), this PR changes font and background colors to make the site darker. This isn't following best practices (note the `!important` in the stylesheets), but I didn't want to do anything drastic like reorder stylesheet importing or otherwise fundamentally change the app. This seems to work great with minimal changes.

Some screenshots:

![image](https://user-images.githubusercontent.com/1746778/145497961-2254c29d-c2ae-4d13-8a19-6fb0dd2a0100.png)

![image](https://user-images.githubusercontent.com/1746778/145497976-76c39152-853a-44a4-9a69-9fa902abe4ce.png)
